### PR TITLE
Add API enpoint for the deleting of recipes by an authenticated user - #152046612

### DIFF
--- a/server/controllers/recipes.js
+++ b/server/controllers/recipes.js
@@ -79,6 +79,29 @@ class Recipe {
       .then(allRecipes => res.status(200).send({ status: 'Success.', data: allRecipes }))
       .catch(error => res.status(400).send(error.message));
   }
+
+  /**
+  * @returns { Object } deleteRecipes
+  *@param { String } req takes in the request
+  *@param { String } res takes in the request
+  */
+
+  static deleteRecipe(req, res) {
+    return recipes
+      .findById(req.params.recipeId)
+      .then((recipe) => {
+        if (!recipe) {
+          return res.status(404).send({ status: 'Not found', message: 'The recipe you are looking for does not exist.' });
+        } else if (recipe.owner !== req.userId) {
+          return res.status(403).send({ status: 'Forbidden.', message: 'You do not have the priviledges to perform this action.' });
+        }
+        return recipe
+          .destroy()
+          .then(() => res.status(200).send({ status: 'Success.', message: 'You have successfully deleted this recipe. Want to add another?' }))
+          .catch(error => res.status(400).send({ status: error.message }));
+      })
+      .catch(error => res.status(400).send({ status: 'Failed', message: error.message }));
+  }
 }
 
 export default Recipe;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -12,8 +12,9 @@ module.exports = (app) => {
   }));
   app.post('/api/v1/users/signup', userController.signUp);
   app.post('/api/v1/users/signin', userController.signIn);
-  app.post('/api/v1/recipes/testAdd', Login.ensureLogin, User.isuser, recipeAdd, recipeController.addRecipe);
+  app.post('/api/v1/recipes', Login.ensureLogin, User.isuser, recipeAdd, recipeController.addRecipe);
   app.put('/api/v1/recipe/:recipeId', Login.ensureLogin, User.isuser, recipeAdd, recipeController.modifyRecipe);
   app.get('/api/v1/recipes', recipeController.getRecipes);
   app.post('/api/v1/recipes/:recipeId', Login.ensureLogin, User.isuser, validateReview, reviewController.addReviews);
+  app.delete('/api/v1/recipes/:recipeId', Login.ensureLogin, User.isuser, recipeController.deleteRecipe);
 };


### PR DESCRIPTION
##  What does this PR do?
Creates the API for the deleting of recipes.

##  Description of task to be completed?
Have the following API endpoints working:
-  DELETE ```localhost:8080/api/v1/recipes/:recipeId```

##  Screenshots
![404](https://user-images.githubusercontent.com/24798364/32214169-457335ec-be1e-11e7-86c9-66bea5193cd8.PNG)

![4041](https://user-images.githubusercontent.com/24798364/32214186-50985f1a-be1e-11e7-8c17-7c51a83093d1.PNG)

![4043](https://user-images.githubusercontent.com/24798364/32214196-56807160-be1e-11e7-9111-558711d220a9.PNG)

##  Relevant pivotal tracker stories
#152046612